### PR TITLE
disabled overscroll behaviour in y direction

### DIFF
--- a/frontend/src/components/RootPage.css
+++ b/frontend/src/components/RootPage.css
@@ -2,6 +2,7 @@ html {
     font-family: sans-serif;
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
+    overscroll-behavior-y: none;
 }
 
 article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary {


### PR DESCRIPTION
Hi. When using the editor in safari, the default overscroll behavior is a bit annoying when scrolling around in the editor. Adding `overscroll-behavior-y: none;` to the page components css disables this.

You can see the behavior here:

https://github.com/user-attachments/assets/40779e26-426a-46d6-9369-0440a26b2bf4

